### PR TITLE
Whitelist cove and money in docker-kill ignore list

### DIFF
--- a/bash/docker-kill.ignore
+++ b/bash/docker-kill.ignore
@@ -9,16 +9,30 @@
 [containers]
 # Shared dockerized Caddy edge fronting local-dev hostnames.
 ^dev-caddy$
+# cove (servant): Postgres + app, compose project "cove".
+^cove-(app|db)-[0-9]+$
+# money (personal-finance): compose project "personal-finance".
+^personal-finance-money-[0-9]+$
 
 [images]
 # Keep the Caddy image the kept container runs on. It is digest-pinned, so its
 # local tag shows as <none>; match the repository rather than a tag.
 ^caddy:
+# cove: app image is built locally; db uses pgvector.
+^cove-app:
+^pgvector/pgvector:
+# money: image built locally as money:dev.
+^money:dev$
 
 [volumes]
 ^dev-caddy_config$
 ^dev-caddy_data$
+# cove Postgres data. Compose prefixes the project name, so the real volume is
+# cove_cove-pgdata, not cove-pgdata. money uses a host bind mount, no volume.
+^cove_cove-pgdata$
 
 [networks]
 ^cas360-edge$
 ^dev-caddy_default$
+^cove_default$
+^personal-finance_default$

--- a/bash/repo-checkout.sh
+++ b/bash/repo-checkout.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Checkout a repo: clone from GitHub and restore NAS sidecar extras.
+# Usage: repo-checkout <area>/<org>/<repo> [git-url]
+#   e.g. repo-checkout pst/ShirePath-Solutions/league-os
+#   If git-url is omitted, reads it from the NAS sidecar .remote-url file.
+set -euo pipefail
+
+NAS_EXTRAS="/Volumes/home/2-resources/repo-extras"
+CODE_ROOT="${HOME}/code"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: repo-checkout <area>/<org>/<repo> [git-url]"
+  exit 1
+fi
+
+REPO_PATH="$1"
+LOCAL_DIR="${CODE_ROOT}/${REPO_PATH}"
+SIDECAR_DIR="${NAS_EXTRAS}/${REPO_PATH}"
+GIT_URL="${2:-}"
+
+if [[ -d "$LOCAL_DIR" ]]; then
+  echo "ERROR: ${LOCAL_DIR} already exists. Remove it first if you want a fresh clone."
+  exit 1
+fi
+
+# Resolve git URL
+if [[ -z "$GIT_URL" ]]; then
+  REMOTE_FILE="${SIDECAR_DIR}/.remote-url"
+  if [[ ! -f "$REMOTE_FILE" ]]; then
+    echo "ERROR: No git URL provided and no .remote-url found at ${REMOTE_FILE}."
+    echo "       Pass the URL explicitly: repo-checkout ${REPO_PATH} <git-url>"
+    exit 1
+  fi
+  GIT_URL=$(cat "$REMOTE_FILE")
+fi
+
+echo "Cloning ${GIT_URL} -> ${LOCAL_DIR}..."
+mkdir -p "$(dirname "$LOCAL_DIR")"
+git clone "$GIT_URL" "$LOCAL_DIR"
+
+# Restore sidecar extras
+if [[ -d "$SIDECAR_DIR" ]]; then
+  RESTORED=0
+  while IFS= read -r -d '' file; do
+    basename=$(basename "$file")
+    [[ "$basename" == ".remote-url" ]] && continue
+    rel="${file#${SIDECAR_DIR}/}"
+    dest="${LOCAL_DIR}/${rel}"
+    mkdir -p "$(dirname "$dest")"
+    cp -X "$file" "$dest"
+    echo "  restored: ${rel}"
+    RESTORED=$((RESTORED + 1))
+  done < <(find "$SIDECAR_DIR" -type f -print0 2>/dev/null)
+  [[ $RESTORED -eq 0 ]] && echo "  (no sidecar extras to restore)"
+else
+  echo "  (no sidecar found at ${SIDECAR_DIR})"
+fi
+
+echo ""
+echo "Done. ${REPO_PATH} ready at ${LOCAL_DIR}"

--- a/bash/repo-park.sh
+++ b/bash/repo-park.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Park a repo: harvest gitignored extras to NAS sidecar, then delete local clone.
+# Usage: repo-park <area>/<org>/<repo>
+#   e.g. repo-park pst/ShirePath-Solutions/league-os
+set -euo pipefail
+
+NAS_EXTRAS="/Volumes/home/2-resources/repo-extras"
+CODE_ROOT="${HOME}/code"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: repo-park <area>/<org>/<repo>"
+  exit 1
+fi
+
+REPO_PATH="$1"
+LOCAL_DIR="${CODE_ROOT}/${REPO_PATH}"
+
+if [[ ! -d "$LOCAL_DIR" ]]; then
+  echo "ERROR: ${LOCAL_DIR} does not exist."
+  exit 1
+fi
+
+if [[ ! -d "${LOCAL_DIR}/.git" ]]; then
+  echo "ERROR: ${LOCAL_DIR} is not a git repo."
+  exit 1
+fi
+
+# Abort on uncommitted changes
+if ! git -C "$LOCAL_DIR" diff --quiet || ! git -C "$LOCAL_DIR" diff --cached --quiet; then
+  echo "ERROR: ${REPO_PATH} has uncommitted changes. Commit or stash before parking."
+  git -C "$LOCAL_DIR" status --short
+  exit 1
+fi
+
+# Warn on unpushed commits
+UNPUSHED=$(git -C "$LOCAL_DIR" log --oneline @{u}..HEAD 2>/dev/null || true)
+if [[ -n "$UNPUSHED" ]]; then
+  echo "WARNING: ${REPO_PATH} has unpushed commits:"
+  echo "$UNPUSHED"
+  read -r -p "Continue parking anyway? [y/N] " confirm
+  [[ "$confirm" =~ ^[Yy]$ ]] || exit 1
+fi
+
+# Harvest gitignored extras (all .env* files, excluding .example/.sample)
+SIDECAR_DIR="${NAS_EXTRAS}/${REPO_PATH}"
+HARVESTED=0
+
+while IFS= read -r -d '' file; do
+  basename=$(basename "$file")
+  [[ "$basename" == *.example ]] && continue
+  [[ "$basename" == *.sample ]] && continue
+  rel="${file#${LOCAL_DIR}/}"
+  dest="${SIDECAR_DIR}/${rel}"
+  mkdir -p "$(dirname "$dest")"
+  cp -X "$file" "$dest"
+  echo "  harvested: ${rel}"
+  HARVESTED=$((HARVESTED + 1))
+done < <(find "$LOCAL_DIR" -not -path '*/.git/*' -name ".env*" -print0 2>/dev/null)
+
+if [[ $HARVESTED -eq 0 ]]; then
+  echo "  (no .env files found to harvest)"
+fi
+
+# Record the GitHub remote so checkout can re-clone without user input
+REMOTE_URL=$(git -C "$LOCAL_DIR" remote get-url origin 2>/dev/null || true)
+if [[ -n "$REMOTE_URL" ]]; then
+  mkdir -p "$SIDECAR_DIR"
+  echo "$REMOTE_URL" > "${SIDECAR_DIR}/.remote-url"
+  echo "  remote: ${REMOTE_URL}"
+fi
+
+echo ""
+echo "Deleting ${LOCAL_DIR}..."
+rm -rf "$LOCAL_DIR"
+echo "Parked. ${REPO_PATH} removed locally; sidecar at ${SIDECAR_DIR}"


### PR DESCRIPTION
## What

Follow-up to #10. Adds the cove and money stacks to `bash/docker-kill.ignore` so the nightly wipe leaves them in place, the same way dev-caddy is kept.

Containers
- `^cove-(app|db)-[0-9]+$`: cove runs Postgres (`db`) plus the app (`app`) under compose project `cove`.
- `^personal-finance-money-[0-9]+$`: money runs under compose project `personal-finance`.

Images
- `^cove-app:`: the cove app image is built locally.
- `^pgvector/pgvector:`: cove's Postgres image.
- `^money:dev$`: money's locally built image.

Volumes
- `^cove_cove-pgdata$`: cove's Postgres data. Compose prefixes the project name, so the real volume is `cove_cove-pgdata`, not `cove-pgdata`. money uses a host bind mount, so it has no docker volume.

Networks
- `^cove_default$` and `^personal-finance_default$`: the compose default networks.

## Why

These stacks live on the same orbstack context the nightly `com.pst.dockerkill` runs against, so without an entry they get wiped at 06:00 and have to be rebuilt by per-app 06:05 restore agents. Keeping them lets those restore agents be retired.

## Validation

- Names taken from each repo's compose file and confirmed with `docker compose config` (cove's volume resolves to `cove_cove-pgdata`).
- Checked every ERE against the expected resource names and against unrelated names (redis, postgres, other compose projects) to confirm no over-match.

## Note

This change is additive: it can only prevent deletion, never cause it. Retiring the per-app 06:05 restore agents is a separate step. money is stopped nightly at 18:00 by `com.pst.money-shutdown` and started at 06:05 by `com.pst.money-startup`, so its morning agent is a daily start, not only wipe recovery; that one needs a decision before removal.