### PR TITLE
Shut down OrbStack after docker-kill cleanup

### DIFF
--- a/bash/docker-kill.sh
+++ b/bash/docker-kill.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
 #
 # Remove all docker containers, images, volumes, and custom networks, except
-# resources matched by the ignore file. The ignore file defaults to
-# docker-kill.ignore next to this script; override it with DOCKER_KILL_IGNORE_FILE.
-# See docker-kill.ignore for the format.
+# resources matched by the ignore file, then shut down the OrbStack daemon
+# itself so it releases the CPU/RAM it was holding. The ignore file defaults
+# to docker-kill.ignore next to this script; override it with
+# DOCKER_KILL_IGNORE_FILE. See docker-kill.ignore for the format.
+#
+# Killing OrbStack takes any whitelisted containers (e.g. the shared Caddy
+# edge) down too -- there is no "docker daemon" left to run them on. Restart
+# OrbStack to bring the daemon, and the whitelisted containers/networks,
+# back. Set DOCKER_KILL_SKIP_ORBSTACK=1 to leave OrbStack running.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IGNORE_FILE="${DOCKER_KILL_IGNORE_FILE:-$SCRIPT_DIR/docker-kill.ignore}"
+SKIP_ORBSTACK="${DOCKER_KILL_SKIP_ORBSTACK:-0}"
 
 log() {
   echo "[docker-kill] $*"
@@ -138,6 +145,40 @@ print_summary() {
   print_resource_table networks docker network ls --format 'table {{.Name}}\t{{.Driver}}'
 }
 
+# Stop the OrbStack app itself, not just the containers running on it. This
+# tears down its Linux VM and Docker daemon so the CPU/RAM/disk it was using
+# is actually released. Whitelisted containers/networks (e.g. the shared
+# Caddy edge) go down with it -- restarting OrbStack brings them back.
+kill_orbstack() {
+  if [ "$SKIP_ORBSTACK" = "1" ]; then
+    log "DOCKER_KILL_SKIP_ORBSTACK=1; leaving OrbStack running"
+    return 0
+  fi
+  if [ "$(uname -s)" != "Darwin" ]; then
+    log "not on macOS; skipping OrbStack shutdown"
+    return 0
+  fi
+  if ! pgrep -q -i -f orbstack; then
+    log "OrbStack is not running"
+    return 0
+  fi
+  if command -v orb >/dev/null 2>&1; then
+    log "stopping OrbStack via 'orb stop'"
+    orb stop >/dev/null 2>&1 || true
+    sleep 2
+  fi
+  if pgrep -q -i -f orbstack; then
+    log "OrbStack still running; force-killing its processes"
+    pkill -i -f orbstack || true
+    sleep 1
+  fi
+  if pgrep -q -i -f orbstack; then
+    log "warning: OrbStack processes still present after force-kill"
+  else
+    log "OrbStack stopped"
+  fi
+}
+
 parse_ignore_file "$IGNORE_FILE"
 print_summary "before:"
 remove_containers
@@ -145,4 +186,5 @@ remove_images
 remove_volumes
 remove_networks
 print_summary "after:"
+kill_orbstack
 log "done"


### PR DESCRIPTION
## Summary
- `docker-kill.sh` already removed non-whitelisted containers, images, **volumes**, and networks while preserving whitelisted ones (`docker-kill.ignore`) - no changes needed there.
- Added a `kill_orbstack` step that runs after the docker cleanup and summary: it stops OrbStack via `orb stop`, then force-kills any lingering OrbStack processes (`pkill`) if it doesn't fully shut down, so the daemon actually releases its CPU/RAM.
- This takes whitelisted resources (e.g. the shared Caddy edge container/networks) down too, since there's no Docker daemon left to run them on - restarting OrbStack brings the daemon and those resources back, since dev-caddy already runs with `restart: unless-stopped`.
- New `DOCKER_KILL_SKIP_ORBSTACK=1` env var to opt out and leave OrbStack running. The step is a no-op on non-macOS or when OrbStack isn't running.

## Test plan
- [x] `bash -n bash/docker-kill.sh` (syntax check)
- [x] Run on a macOS machine with OrbStack running and confirm containers/images/volumes/networks not on the whitelist are removed, whitelisted ones survive, and OrbStack fully quits afterward
- [x] Confirm restarting OrbStack brings back the whitelisted Caddy container/networks (verified against dev-caddy's real compose config, which has `restart: unless-stopped`; it comes back running)
- [x] Confirm `DOCKER_KILL_SKIP_ORBSTACK=1` leaves OrbStack running
