### PR TITLE
Fix docker-kill network whitelist and OrbStack shutdown

### DIFF
--- a/bash/docker-kill.ignore
+++ b/bash/docker-kill.ignore
@@ -9,7 +9,7 @@
 [containers]
 # Shared dockerized Caddy edge fronting local-dev hostnames.
 ^dev-caddy$
-# cove (servant): Postgres + app, compose project "cove".
+# cove: Postgres + app, compose project "cove".
 ^cove-(app|db)-[0-9]+$
 
 [images]
@@ -28,5 +28,11 @@
 ^cove_cove-pgdata$
 
 [networks]
-^dev-caddy_default$
 ^cove_default$
+# journey-to-jericho: external edge network joining the shared dev-caddy.
+# Certs live in dev-caddy_data; this net has no state of its own, kept only so
+# the stack can rejoin dev-caddy without recreating it.
+^j2j-edge$
+# league-os: external edge network joining the shared dev-caddy. Same reasoning
+# as j2j-edge above.
+^leagueos-edge$

--- a/bash/docker-kill.sh
+++ b/bash/docker-kill.sh
@@ -158,7 +158,12 @@ kill_orbstack() {
     log "not on macOS; skipping OrbStack shutdown"
     return 0
   fi
-  if ! pgrep -q -i -f orbstack; then
+  # Scope to our own processes: the root-owned dev.orbstack.OrbStack.privhelper
+  # LaunchDaemon also matches "orbstack" but is a persistent system helper we
+  # can't signal and don't need to -- it holds no VM/CPU/RAM of its own.
+  local user_id
+  user_id="$(id -u)"
+  if ! pgrep -q -i -f -u "$user_id" orbstack; then
     log "OrbStack is not running"
     return 0
   fi
@@ -167,12 +172,12 @@ kill_orbstack() {
     orb stop >/dev/null 2>&1 || true
     sleep 2
   fi
-  if pgrep -q -i -f orbstack; then
+  if pgrep -q -i -f -u "$user_id" orbstack; then
     log "OrbStack still running; force-killing its processes"
-    pkill -i -f orbstack || true
+    pkill -i -f -u "$user_id" orbstack || true
     sleep 1
   fi
-  if pgrep -q -i -f orbstack; then
+  if pgrep -q -i -f -u "$user_id" orbstack; then
     log "warning: OrbStack processes still present after force-kill"
   else
     log "OrbStack stopped"


### PR DESCRIPTION
Whitelists j2j-edge and leagueos-edge networks (drops stale dev-caddy_default entry) and scopes OrbStack pgrep/pkill to the current user, fixing a permission error against the root-owned privileged helper daemon.